### PR TITLE
Adding support for Cactus and Sugar Cane

### DIFF
--- a/common/net/funshinex/greenjukebox/block/BlockGreenJukebox.java
+++ b/common/net/funshinex/greenjukebox/block/BlockGreenJukebox.java
@@ -73,7 +73,10 @@ public class BlockGreenJukebox extends BlockJukeBox {
         			world.playAuxSFXAtEntity((EntityPlayer)null, 1005, x, y, z, hand.itemID);
         		}
         		else {
-        			player.addChatMessage("What are you holding?");
+        			if(!world.isRemote)
+        			{
+        				player.addChatMessage("What are you holding?");
+        			}
         		}
         			
         	}

--- a/common/net/funshinex/greenjukebox/block/BlockInfo.java
+++ b/common/net/funshinex/greenjukebox/block/BlockInfo.java
@@ -23,4 +23,9 @@ public class BlockInfo {
     public static int GROWTH_RANGE;
     public static final String GROWTH_RANGE_KEY="GrowthRange";
     public static final int GROWTH_RANGE_DEFAULT=7;
+    
+    
+    public static boolean LIMIT_GROWTH_TO_VANILLA;
+    public static final String LIMIT_GROWTH_KEY = "CactusVanillaGrowthHight";
+    public static final boolean LIMIT_GROWTH_DEFULT = true;
 }

--- a/common/net/funshinex/greenjukebox/config/ConfigHandler.java
+++ b/common/net/funshinex/greenjukebox/config/ConfigHandler.java
@@ -16,6 +16,7 @@ public class ConfigHandler {
 		BlockInfo.GROWTH_TIME = config.get("General", BlockInfo.GROWTH_TIME_KEY, BlockInfo.GROWTH_TIME_DEFAULT).getInt();
 		BlockInfo.GROWTH_RANGE = config.get("General", BlockInfo.GROWTH_RANGE_KEY, BlockInfo.GROWTH_RANGE_DEFAULT).getInt();
 		
+		BlockInfo.LIMIT_GROWTH_TO_VANILLA = config.get("General", BlockInfo.LIMIT_GROWTH_KEY, BlockInfo.LIMIT_GROWTH_DEFULT).getBoolean(true);
 		
 		config.save();
 	}

--- a/common/net/funshinex/greenjukebox/util/GeneralUtil.java
+++ b/common/net/funshinex/greenjukebox/util/GeneralUtil.java
@@ -2,6 +2,7 @@ package net.funshinex.greenjukebox.util;
 
 import java.util.Random;
 
+import net.funshinex.greenjukebox.block.BlockInfo;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCocoa;
 import net.minecraft.block.BlockCrops;
@@ -45,6 +46,27 @@ public class GeneralUtil {
             }
 
             return true;
+        }
+        else if(id == Block.cactus.blockID || id == Block.reed.blockID)
+        {
+        	if(!world.isRemote)
+        	{
+        		if((double)world.rand.nextFloat() < 0.45 && world.isAirBlock(x, y+1, z))
+        		{
+        			if(BlockInfo.LIMIT_GROWTH_TO_VANILLA)
+        			{
+        				if(world.getBlockId(x,y-2,z) != id)
+        				{
+        					world.setBlock(x, y+1, z, id);
+        				}
+        			}
+        			else
+        			{
+        				world.setBlock(x, y+1, z, id);
+        			}
+        		}
+        	}
+        	return true;
         }
         else if (id != Block.mushroomBrown.blockID && id != Block.mushroomRed.blockID)
         {


### PR DESCRIPTION
Small change to allow Cactus and Sugar Cane to grow also added Config
option for limiting the growth of Sugar Cane and Cactus, this is true by
defult meaning that the Sugar Cane/Cactus will grow no more than 3
blocks high.
